### PR TITLE
Fix filter

### DIFF
--- a/R/figure_functions.R
+++ b/R/figure_functions.R
@@ -21,7 +21,7 @@ stationMap <- function(data) {
                        popup = ~as.character(platformname), 
                        label = ~as.character(serialnumber), 
                        color = "red", fillOpacity = 0.5,
-                       clusterOptions = markerClusterOptions()
+                       clusterOptions = markerClusterOptions(disableClusteringAtZoom = 10, spiderfyOnMaxZoom = FALSE)
       )
   }
 }

--- a/R/filtering_functions.R
+++ b/R/filtering_functions.R
@@ -344,7 +344,6 @@ makeFilterChain <- function(db = FALSE) {
   for(xx in seq_len(length(sub$cruiseseries))) {
     yy <- sub$cruiseseries[[xx]]
     filterChain <- append(filterChain, paste0("cruiseseriescode %like% '", yy, ",%' | cruiseseriescode %like% '%,", yy,"' | cruiseseriescode %in% c(", yy,")"))
-    print(filterChain)
   }
 
   ## Platform
@@ -363,17 +362,9 @@ makeFilterChain <- function(db = FALSE) {
   ## Serial number
   
   if(db) {
-    if(input$toggleSerialnumberDb == TRUE) {
-      sub$serialnumber <- processRangeInput(input$selSerialnumberDbRange, index$serialnumber)
-    } else {
-      sub$serialnumber <- input$selSerialnumberDb
-    }
+    sub$serialnumber <- processRangeInput(input$selSerialnumberDb, index$serialnumber)
   } else {
-    if(input$toggleSerialnumber == TRUE) {
-      sub$serialnumber <- processRangeInput(input$subSerialnumberRange, rv$all$serialnumber)
-    } else {
-      sub$serialnumber <- input$subSerialnumber
-    }
+    sub$serialnumber <- processRangeInput(input$subSerialnumber, rv$all$serialnumber)
   }
   
   if (!is.null(sub$serialnumber)) {
@@ -384,17 +375,9 @@ makeFilterChain <- function(db = FALSE) {
   ## Gear
   
   if(db) {
-    if(input$toggleGearDb == TRUE) {
-      sub$gear <- processRangeInput(input$selGearDbRange, index$gear)
-    } else {
-      sub$gear <- input$selGearDb
-    }
+    sub$gear <- processRangeInput(input$selGearDb, index$gear)
   } else {
-    if(input$toggleGear == TRUE) {
-      sub$gear <- processRangeInput(input$subGearRange, rv$all$gear)
-    } else {
-      sub$gear <- input$subGear
-    }
+    sub$gear <- processRangeInput(input$subGear, rv$all$gear)
   }
   
   if (!is.null(sub$gear)) {
@@ -456,11 +439,16 @@ makeFilterChain <- function(db = FALSE) {
   } else {
     sub$lon <- as.numeric(input$subLon)
   }
-  
+ 
   if(all(sub$lon == c(-180, 180))) sub$lon <- NULL
   
   if (!is.null(sub$lon)) {
-    filterChain <- append(filterChain, paste0("longitudestart >= ",sub$lon[1], " & longitudestart <= ", sub$lon[2])) 
+    if(sub$lon[1] > rv$all$min.lon) {
+      filterChain <- append(filterChain, paste0("longitudestart > ",sub$lon[1]))
+    }
+    if(sub$lon[2] < rv$all$max.lon) {
+      filterChain <- append(filterChain, paste0("longitudestart < ",sub$lon[2]))
+    }
   }
   
   ## Latitude
@@ -474,7 +462,12 @@ makeFilterChain <- function(db = FALSE) {
   if(all(sub$lat == c(-90, 90))) sub$lat <- NULL
   
   if (!is.null(sub$lat)) {
-    filterChain <- append(filterChain, paste0("latitudestart >= ", sub$lat[1], " & latitudestart <= ", sub$lat[2]))
+    if(sub$lat[1] > rv$all$min.lat) {
+      filterChain <- append(filterChain, paste0("latitudestart > ",sub$lat[1]))
+    }
+    if(sub$lat[2] < rv$all$max.lat) {
+      filterChain <- append(filterChain, paste0("latitudestart < ",sub$lat[2]))
+    }
   }
   
   # if (!identical(as.numeric(input$subLon), c(rv$all$min.lon, rv$all$max.lon))) {
@@ -490,7 +483,10 @@ makeFilterChain <- function(db = FALSE) {
   # } else {
   #   sub$lat <- NULL
   # }
-  
+
+  print("We have filter:") 
+  print(filterChain)
+ 
   list(filterChain = filterChain, sub = sub)
 }
 

--- a/R/filtering_functions.R
+++ b/R/filtering_functions.R
@@ -75,6 +75,8 @@ updateFilterform <- function(db = FALSE, loadDb = FALSE) {
     updateSelectizeInput(session, "selGearDb", choices = index$gear, server = TRUE)
     updateSelectizeInput(session, "selGearCategoryDb", choices = index$gearcategory, server = TRUE)
     updateDateRangeInput(session, "selDateDb", start = index$date[[1]], end = index$date[[2]])
+    updateSliderInput(session, "selLonDb", min = -180,max = 180, value = c(-180, 180), step = 0.1)
+    updateSliderInput(session, "selLatDb", min = -90, max = 90, value = c(-90, 90), step = 0.1)
   } else if(db) {
     updateSelectizeInput(session, "selMissionTypeDb", choices = rv$all$missiontypename, server = TRUE)
     updateSelectizeInput(session, "selCruiseSeriesDb", choices = rv$all$cruiseseries, server = TRUE)

--- a/R/filtering_functions.R
+++ b/R/filtering_functions.R
@@ -301,9 +301,9 @@ makeFilterChain <- function(db = FALSE) {
   ## Year
   
   if(db) {
-    sub$year <- input$selYearDb
+    sub$year <- processRangeInput(input$selYearDb, index$year)
   } else {
-    sub$year <- input$subYear
+    sub$year <- processRangeInput(input$subYear, rv$all$startyear)
   }
   
   if (!is.null(sub$year)) { 

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -104,3 +104,9 @@ processRangeInput <- function(inp, idx) {
   return(ret)
 }
 
+# Pretty decimal for csv writing (might be slow for large data.table)
+prettyDec <- function(dt) {
+  cols <- names(dt)[sapply(dt, class) == "numeric"]
+  for (j in cols) suppressWarnings(set(dt, j = j, value = as.numeric(format(dt[[j]]))))
+  return(dt)
+}

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -92,8 +92,10 @@ round_any <- function(x, accuracy, f = round) {
 
 processRangeInput <- function(inp, idx) {
   # Sanitize input
+  if(is.null(inp))
+    return(NULL)
   spl <- trimws(unlist(strsplit(inp, "[,]")))
-  toEval <- grep("^\\d+:\\d+$", spl, perl = TRUE, value = TRUE)
+  toEval <- grep("^\\d+$|^\\d+:\\d+$", spl, perl = TRUE, value = TRUE)
   gearRange <- try(eval(parse(text = paste0("c(", paste(toEval, collapse = ","), ")"))))
   if(class(gearRange ) != "try-error")
     ret <- intersect(idx, gearRange)

--- a/app.R
+++ b/app.R
@@ -1537,8 +1537,8 @@ server <- shinyServer(function(input, output, session) {
           
           fileName <- paste0(input$downloadDataType[i], ".csv")
           write.csv(
-            eval(parse(text = paste("rv", input$downloadDataType[i], sep = "$"))),
-            fileName, row.names = FALSE) 
+            prettyDec(eval(parse(text = paste("rv", input$downloadDataType[i], sep = "$")))),
+            fileName, row.names = FALSE, na = "") 
           files <- c(fileName,files)
         }
         #create the zip file
@@ -1567,11 +1567,11 @@ server <- shinyServer(function(input, output, session) {
         
       } else {
         tmp <- switch(input$downloadDataType,
-                      "mission" = rv$mission,
-                      "stnall" = rv$stnall,
-                      "indall" = rv$indall)
+                      "mission" = prettyDec(rv$mission),
+                      "stnall" = prettyDec(rv$stnall),
+                      "indall" = prettyDec(rv$indall))
         
-        write.csv(tmp, file, row.names = FALSE) 
+        write.csv(tmp, file, row.names = FALSE, na = "") 
       }
     }
   )

--- a/app.R
+++ b/app.R
@@ -939,7 +939,7 @@ server <- shinyServer(function(input, output, session) {
         
         # Copy the indexing script from BioticExplorerServer::indexDatabase. 
         if(!exists("index")) {
-          index <<- list()
+          index <- list()
           index$missiontypename <- rv$inputData$mission %>% select(missiontypename) %>% distinct() %>% pull() %>% sort()
           index$cruise <- rv$inputData$mission %>% select(cruise) %>% distinct() %>% pull() %>% sort()
           index$year <- rv$inputData$mission %>% select(startyear) %>% distinct() %>% pull() %>% sort()
@@ -952,6 +952,9 @@ server <- shinyServer(function(input, output, session) {
           index$nmeasured <- rv$inputData$indall %>% select(length) %>% count() %>% pull()
           index$downloadstart <- rv$inputData$meta %>% select(timestart) %>% pull()
           index$downloadend <- rv$inputData$meta %>% select(timeend) %>% pull()
+
+          # Make index as global
+          index <<- index
         }
         
         updateFilterform(loadDb = TRUE)

--- a/app.R
+++ b/app.R
@@ -26,7 +26,7 @@ required.packages <- c("shiny" = TRUE, "shinyFiles" = TRUE, "shinydashboard" = T
                        "data.table" = TRUE,  "tidyverse" = TRUE, "dtplyr" = TRUE, "devtools" = FALSE,
                        "leaflet" = TRUE, "leaflet.minicharts" = TRUE, "plotly" = TRUE, 
                        "openxlsx" = FALSE, "scales" = FALSE, "fishmethods" = FALSE, "viridis" = FALSE,
-                       "mapview" = FALSE, "DBI" = FALSE) ## TRUE means that the package should be loaded. FALSE that the functions are used without loading the package
+                       "mapview" = FALSE, "DBI" = FALSE, "bsplus" = TRUE) ## TRUE means that the package should be loaded. FALSE that the functions are used without loading the package
 
 new.packages <- names(required.packages)[!(names(required.packages) %in% installed.packages()[,"Package"])]
 if (length(new.packages) > 0) install.packages(new.packages)
@@ -119,7 +119,7 @@ header <- dashboardHeader(title = div(
            loadingLogo("https://www.hi.no", "logo.png", "logo_bw.png", 
                        height = "40px")), 
     column(width = 10, p("Biotic Explorer", align = "center"))
-  )
+  ), use_bs_tooltip()
 ),
 dropdownMenu(type = "notifications", headerText = scan("VERSION", what = "character", quiet = TRUE),
              icon = icon("cog"), badgeStatus = NULL,
@@ -186,7 +186,6 @@ body <-
       ## Info tab ####   
       
       tabItem("info", 
-              
               fluidRow(
                 column(width = 12,
                        h1("Welcome to the Biotic Explorer", align = "center"),
@@ -265,7 +264,8 @@ body <-
                          fluidRow(
                            column(6, 
                                   selectizeInput(inputId = "subYear", label = "Year:",
-                                                 choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
+                                                 choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$"))
+                                                 %>% bs_embed_tooltip(title = "Range is supported (e.g., 1990:1995). Write manually and click \"Add ...\".", trigger="focus"),
                                   selectizeInput(inputId = "subCruise", label = "Cruise number:",
                                                  choices = NULL, multiple = TRUE),
                                   selectizeInput(inputId = "subPlatform", label = "Platform name:",
@@ -279,9 +279,11 @@ body <-
                                                  choices = NULL, multiple = TRUE),
                                   selectizeInput(inputId = "subSerialnumber", 
                                                  label = "Serial number:",
-                                                 choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
+                                                 choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$"))
+                                                 %>% bs_embed_tooltip(title = "Range is supported (e.g., 10000:10010). Write manually and click \"Add ...\".", trigger="focus"),
                                   selectizeInput(inputId = "subGear", label = "Gear code:",
-                                                 choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
+                                                 choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$"))
+                                                 %>% bs_embed_tooltip(title = "Range is supported (e.g., 3700:3710). Write manually and click \"Add ...\".", trigger="focus"),
                                   selectizeInput(inputId = "subMissionType", label = "Mission type:",
                                                  choices = NULL, multiple = TRUE)
                            )),
@@ -370,8 +372,8 @@ body <-
                              column(6,
                                     selectizeInput(inputId = "selYearDb", 
                                                    label = "Year:",
-                                                   choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
-                                    
+                                                   choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$"))
+                                                   %>% bs_embed_tooltip(title = "Range is supported (e.g., 1990:1995). Write manually and click \"Add ...\".", trigger="focus"),
                                     selectizeInput(inputId = "selSpeciesDb", 
                                                    label = "Species:", 
                                                    choices = NULL, multiple = TRUE),
@@ -382,11 +384,13 @@ body <-
                                     
                                     selectizeInput(inputId = "selSerialnumberDb", 
                                                    label = "Serial number:",
-                                                   choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
+                                                   choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$"))
+                                                   %>% bs_embed_tooltip(title = "Range is supported (e.g., 10000:10010). Write manually and click \"Add ...\".", trigger="focus"),
                                     
                                     selectizeInput(inputId = "selGearDb", 
                                                    label = "Gear code:",
-                                                   choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
+                                                   choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$"))
+                                                   %>% bs_embed_tooltip(title = "Range is supported (e.g., 3700:3710). Write manually and click \"Add ...\".", trigger="focus"),
                                     
                                     selectizeInput(inputId = "selGearCategoryDb", 
                                                    label = "Gear category:",
@@ -858,7 +862,7 @@ ui <- dashboardPage(header, sidebar, body)
 ## Server ####
 
 server <- shinyServer(function(input, output, session) {
-  
+
   ## Options ####
   
   options(shiny.maxRequestSize = 1000*1024^2) ## This sets the maximum file size for upload. 1000 = 1 Gb. 

--- a/app.R
+++ b/app.R
@@ -265,7 +265,7 @@ body <-
                          fluidRow(
                            column(6, 
                                   selectizeInput(inputId = "subYear", label = "Year:",
-                                                 choices = NULL, multiple = TRUE),
+                                                 choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
                                   selectizeInput(inputId = "subCruise", label = "Cruise number:",
                                                  choices = NULL, multiple = TRUE),
                                   selectizeInput(inputId = "subPlatform", label = "Platform name:",
@@ -370,7 +370,7 @@ body <-
                              column(6,
                                     selectizeInput(inputId = "selYearDb", 
                                                    label = "Year:",
-                                                   choices = NULL, multiple = TRUE),
+                                                   choices = NULL, multiple = TRUE, options = list(create = TRUE, createFilter = "^\\d+$|^\\d+:\\d+$")),
                                     
                                     selectizeInput(inputId = "selSpeciesDb", 
                                                    label = "Species:", 


### PR DESCRIPTION
DB & Files:
- Now we don't need a special toggle to enable range search
- Fix Long/Lat filters always triggered despite no movements in the sliders
- Enable range filter for year
- Add tooltip to explain about range format for certain input values
- Add button to show the active filter

DB only:
- Fix when user didn't specify any filter
- Bug fix for reset in DB mode not resetting the sliders
- index variable must be in the global scope